### PR TITLE
Update 05_implement_user_list.md

### DIFF
--- a/play2.5-slick3.1/markdown/05_implement_user_list.md
+++ b/play2.5-slick3.1/markdown/05_implement_user_list.md
@@ -67,7 +67,7 @@ def list = Action.async { implicit rs =>
   // IDの昇順にすべてのユーザ情報を取得
   db.run(Users.sortBy(t => t.id).result).map { users =>
     // 一覧画面を表示
-    Ok(views.html.user.list(users))
+    Ok(views.html.list(users))
   }
 }
 ```


### PR DESCRIPTION
「appディレクトリ配下にviews.userパッケージを作成」して、list.scala.htmlを作成する場合、
ok(views.html.user.list(users))ではなく、ok(views.html.list(users))にならないのでしょうか？
（自分の環境ではそれで動作しているので、もしかしたらlist.scala.htmlを作った場所が違うのかもしれません。勘違いであればすみません）