### PR TITLE
edit ScalikeJDBC 2.5 content(models & image url)

### DIFF
--- a/content/play2.5-scalikejdbc2.5/implement_user_form.md
+++ b/content/play2.5-scalikejdbc2.5/implement_user_form.md
@@ -43,7 +43,7 @@ object UserController {
 続いて`views.user`パッケージに`edit.scala.html`を実装します。引数には`Form`のインスタンスと、プルダウンで選択する会社情報を格納した`Seq`を受け取ります。
 
 ```html
-@(userForm: Form[controllers.UserController.UserForm], companies: Seq[models.Tables.CompaniesRow])(implicit request: Request[Any], messages: Messages)
+@(userForm: Form[controllers.UserController.UserForm], companies: Seq[models.Companies])(implicit request: Request[Any], messages: Messages)
 
 @import helper._
 

--- a/content/play2.5-scalikejdbc2.5/implement_user_list.md
+++ b/content/play2.5-scalikejdbc2.5/implement_user_list.md
@@ -109,4 +109,4 @@ SELECT * FROM USERS ORDER BY ID
 
 ここまで実装したらブラウザから http://localhost:9000/user/list にアクセスします（`sbt run`を実行していない場合は実行してください）。すると以下のような画面が表示されるはずです。
 
-![ユーザ一覧画面](../images/play2.5-scalikejdbc2.5
+![ユーザ一覧画面](../images/play2.5-scalikejdbc2.5/user_list.png)


### PR DESCRIPTION
ScalikeJDBC 2.5 版の User Form の説明で、引数がSlick版になっているのを見つけたので修正してみました。また、画像のリンク切れもありましたのでパスを修正しています。