### PR TITLE
(refs #17) fix scalikejdbcGen command

### DIFF
--- a/content/play2.5-scalikejdbc2.5/preparation_of_db.md
+++ b/content/play2.5-scalikejdbc2.5/preparation_of_db.md
@@ -93,7 +93,7 @@ scalikejdbcSettings
 ではコードを自動生成してみましょう。`play2-hands-on`プロジェクトのルートディレクトリで以下のコマンドを実行します。
 
 ```
-sbt "scalikejdbcGen USERS, COMPANIES"
+sbt "scalikejdbcGenAll"
 ```
 
 すると`play2-hands-on`プロジェクトの`app/models`パッケージにモデルクラスが生成されます。


### PR DESCRIPTION
こちらを確認すると全てのテーブルに対して生成するコマンドがありました！
`
scalikejdbcGenAll
`
該当のプラグイン部分です（試しに実行したら２つ生成されました）。
https://github.com/scalikejdbc/scalikejdbc/blob/master/scalikejdbc-mapper-generator/src/main/scala/scalikejdbc/mapper/ScalikejdbcPlugin.scala#L33

テーブル名指定に関しては以下のドキュメントの仕様のようです。
http://scalikejdbc.org/documentation/2.x/reverse-engineering.html

よろしくお願いします。