### PR TITLE
fix dir

### DIFF
--- a/.github/workflows/deploy-hugo-to-gh-pages.yml
+++ b/.github/workflows/deploy-hugo-to-gh-pages.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./public
+          path: ./docs
 
   # Deployment job
   deploy:


### PR DESCRIPTION
# Changes

- fix directory for uploading static files
  - this actions came from official website ( https://gohugo.io/hosting-and-deployment/hosting-on-github/ ).
  - by default, output dir is set as `public`, but in this project, it is `docs`.
  - we should change upload target dir from `public` to `docs`